### PR TITLE
Add TodayPickup proxy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,6 @@ uvicorn app.main:app --reload
 
 서버 실행 후 다음 URL에서 API 문서를 확인할 수 있습니다:
 - Swagger UI: http://localhost:8000/docs
-- ReDoc: http://localhost:8000/redoc 
+- ReDoc: http://localhost:8000/redoc
+
+외부 TodayPickup API에 대한 프록시 엔드포인트는 `/todaypickup` 경로 아래에 위치합니다. 예를 들어 `GET /todaypickup/v2/some-endpoint`와 같이 호출할 수 있습니다.

--- a/app/controllers/todaypickup_controller.py
+++ b/app/controllers/todaypickup_controller.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import Any, Dict, Optional
+
+from app.services.todaypickup_service import TodayPickupService
+
+
+class TodayPickupController:
+    """Controller exposing endpoints that proxy requests to the TodayPickup API."""
+
+    def __init__(self) -> None:
+        self.router = APIRouter(prefix="/todaypickup", tags=["todaypickup"])
+        self.service = TodayPickupService()
+        self._register_routes()
+
+    def _register_routes(self) -> None:
+        self.router.get("/{full_path:path}")(self.proxy_get)
+        self.router.post("/{full_path:path}")(self.proxy_post)
+
+    async def proxy_get(self, full_path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        response = await self.service.request("GET", f"/{full_path}", params=params)
+        if response.is_success:
+            return response.json()
+        raise HTTPException(status_code=response.status_code, detail=response.text)
+
+    async def proxy_post(
+        self,
+        full_path: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        response = await self.service.request("POST", f"/{full_path}", data=data)
+        if response.is_success:
+            return response.json()
+        raise HTTPException(status_code=response.status_code, detail=response.text)

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.controllers.user_controller import UserController
+from app.controllers.todaypickup_controller import TodayPickupController
 from app.config.database import engine, Base
 
 # 데이터베이스 테이블 생성
@@ -25,6 +26,8 @@ app.add_middleware(
 # 라우터 등록
 user_controller = UserController()
 app.include_router(user_controller.router)
+todaypickup_controller = TodayPickupController()
+app.include_router(todaypickup_controller.router)
 
 @app.get("/")
 async def root():

--- a/app/services/todaypickup_service.py
+++ b/app/services/todaypickup_service.py
@@ -1,0 +1,29 @@
+import httpx
+from typing import Any, Dict, Optional
+
+
+class TodayPickupService:
+    """Service for interacting with the TodayPickup external API."""
+
+    BASE_URL = "https://admin.todaypickup.com"
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> httpx.Response:
+        """Make an HTTP request to the TodayPickup API."""
+        url = f"{self.BASE_URL}{path}"
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method,
+                url,
+                params=params,
+                json=data,
+                headers=headers,
+            )
+        return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ uvicorn==0.23.2
 sqlalchemy==2.0.20
 psycopg2-binary==2.9.7
 pydantic==2.3.0
-alembic==1.12.0 
+alembic==1.12.0
+httpx==0.25.0


### PR DESCRIPTION
## Summary
- add service for TodayPickup API requests
- add controller exposing `/todaypickup` routes that proxy to external API
- include new controller in main router
- document new endpoints in README
- add httpx dependency

## Testing
- `python -m py_compile app/services/todaypickup_service.py app/controllers/todaypickup_controller.py`
- `pytest -q` *(fails: command not found)*